### PR TITLE
Исправление ошибок старта уровня

### DIFF
--- a/app/src/core/bg.canvas.ts
+++ b/app/src/core/bg.canvas.ts
@@ -11,9 +11,11 @@ import type {AssetMap, Sprite} from './sprites/types';
 import type {Level, Point} from '~/core/types';
 
 let ctx: CanvasRenderingContext2D;
+let width: number;
+let height: number;
 
 export function setBgCanvas(canvasElement: HTMLCanvasElement | null): void {
-    ({ctx} = setCanvas(canvasElement));
+    ({ctx, width, height} = setCanvas(canvasElement));
 }
 
 function getRenderPattern([x, y]: Point): Point[] {
@@ -34,6 +36,10 @@ function getRenderPattern([x, y]: Point): Point[] {
         [x + 1, y - 1],
         [x - 1, y - 1]
     ];
+}
+
+export function clearMap(): void {
+    ctx.clearRect(0, 0, width, height);
 }
 
 export function drawMap(fullLevel: Level, position?: Point): void {
@@ -65,24 +71,24 @@ function redraw(
     const OBJECTS = sprites.objects;
     const pattern = getRenderPattern(position);
 
-    pattern.forEach(([i, j]) => {
+    pattern.forEach(([x, y]) => {
         // Граница карты
-        if (i < 0 || j < 0 || i >= level.map.length || j >= level.map[0].length) {
+        if (x < 0 || y < 0 || y >= level.map.length || x >= level.map[0].length) {
             return;
         }
-        const {asset: backgroundAsset} = level.map[i][j];
+        const {asset: backgroundAsset} = level.map[y][x];
         if (backgroundAsset) {
             if (backgroundAsset.type === 'WALL') {
-                drawImage(j, i, WALL[backgroundAsset.part]);
+                drawImage(x, y, WALL[backgroundAsset.part]);
             } else {
-                drawImage(j, i, FLOOR[backgroundAsset.part]);
+                drawImage(x, y, FLOOR[backgroundAsset.part]);
             }
         }
 
-        if (j === level.keyPoint[0] && i === level.keyPoint[1]) {
+        if (x === level.keyPoint[0] && y === level.keyPoint[1]) {
             drawSpriteInPoint(level.keyPoint, OBJECTS.KEY);
         }
-        if (j === level.endPoint[0] && i === level.endPoint[1]) {
+        if (x === level.endPoint[0] && y === level.endPoint[1]) {
             drawSpriteInPoint(level.endPoint, OBJECTS.DOOR);
         }
     });

--- a/app/src/core/engine.ts
+++ b/app/src/core/engine.ts
@@ -1,11 +1,11 @@
 import {Middleware} from 'redux';
 
-import {drawMap} from './bg.canvas';
+import {clearMap, drawMap} from './bg.canvas';
 import {movef} from './main.canvas';
 import {STATE} from './params';
 import {moves} from './spirit.canvas';
 
-import type {ArrowPressCallback, EmptyCallback, GameCharacterMove, GameStatePoint, Level} from './types';
+import type {ArrowPressCallback, EmptyCallback, GameCharacterMove, GameStatePoint, Level, Point} from './types';
 import type {AppStoreState} from '~/store/types';
 
 const LEVEL_SIZE = {
@@ -47,8 +47,10 @@ export function createGame(): void {
 let currentGameLevel: Level;
 
 export function loadLevel(level: Level): void {
-    currentGameLevel = level;
+    clearMap();
     drawMap(level);
+    currentGameLevel = level;
+    setCharStartPosition(level.startPoint);
     // eslint-disable-next-line no-console
     console.log('[loadLevel]');
 }
@@ -56,15 +58,12 @@ export function loadLevel(level: Level): void {
 export function play(): void {
     // eslint-disable-next-line no-console
     console.log('[play]');
-    setCharStartPosition();
-
     loop();
 }
 
-const setCharStartPosition = (): void => {
-    [charMove.posx, charMove.posy] = gameCurrentLevel.startPoint || [0, 0];
+const setCharStartPosition = (startPoint: Point): void => {
+    [charMove.posx, charMove.posy] = startPoint;
     charMove.needRender = true;
-    characterMove();
 };
 
 export function pauseGame(): void {
@@ -182,7 +181,7 @@ function characterMove(): void {
     if (charMove.needRender && checkLimit()) {
         charMove.needRender = false;
         if (currentGameLevel) {
-            drawMap(currentGameLevel, [charMove.posy, charMove.posx]);
+            drawMap(currentGameLevel, [charMove.posx, charMove.posy]);
         }
         movef(charMove.posx, charMove.posy);
     }


### PR DESCRIPTION
Добавлена очистка уровня перед отрисовкой, тк при смене уровня новый
 накладывается на предыдущий
Установка стартовой позиции перенесена из старта в загрузку уровня, тк
 после паузы позиция сбрасывается
Удален вызов движения персонажа в момент установки стартовой позиции, тк
 может возникнуть ошибка из за непрогруженных спрайтах CHAR
Переименованы и поправлены переменные координат в цикле отрисовки карты